### PR TITLE
Integrate Symfony Validator for core validation logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/finder": "^7.0",
         "symfony/process": "^7.4",
         "symfony/http-foundation": "^7.4",
-        "symfony/event-dispatcher": "^7.4"
+        "symfony/event-dispatcher": "^7.4",
+        "symfony/validator": "^7.4"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1155109b8a8a4a370771a331ab9d036",
+    "content-hash": "8a0e3d3ecc783e9a6a4070f986ddc128",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -3849,6 +3849,86 @@
             "time": "2025-01-02T08:10:11+00:00"
         },
         {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-08T02:45:35+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v7.4.5",
             "source": {
@@ -4198,6 +4278,110 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/twig-bridge/tree/v7.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T08:59:58+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v7.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "fcec92c40df1c93507857da08226005573b655c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/fcec92c40df1c93507857da08226005573b655c6",
+                "reference": "fcec92c40df1c93507857da08226005573b655c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php83": "^1.27",
+                "symfony/translation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "doctrine/lexer": "<1.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<7.0",
+                "symfony/expression-language": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/intl": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/var-exporter": "<6.4.25|>=7.0,<7.3.3",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4.3|^7.0.3|^8.0",
+                "symfony/type-info": "^7.1.8",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/Resources/bin/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to validate values",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -6403,13 +6587,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Core/Validation/Constraint/Unique.php
+++ b/src/Core/Validation/Constraint/Unique.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Core\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Unique extends Constraint
+{
+    public string $message = 'Значення поля "{{ field }}" вже існує.';
+    public string $table;
+    public string $column;
+    public ?int $ignoreId = null;
+
+    public function __construct(
+        string $table,
+        string $column,
+        ?int $ignoreId = null,
+        ?string $message = null,
+        ?array $groups = null,
+        $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+
+        $this->table = $table;
+        $this->column = $column;
+        $this->ignoreId = $ignoreId;
+
+        if ($message !== null) {
+            $this->message = $message;
+        }
+    }
+
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Core/Validation/Constraint/UniqueValidator.php
+++ b/src/Core/Validation/Constraint/UniqueValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Core\Validation\Constraint;
+
+use App\Database\Database;
+use PDO;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class UniqueValidator extends ConstraintValidator
+{
+    private ?PDO $pdo;
+
+    public function __construct(?PDO $pdo = null)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Unique) {
+            throw new UnexpectedTypeException($constraint, Unique::class);
+        }
+
+        if (empty($value)) {
+            return;
+        }
+
+        try {
+            $pdo = $this->pdo ?? Database::getInstance();
+
+            $sql = "SELECT COUNT(*) FROM `{$constraint->table}` WHERE `{$constraint->column}` = :value";
+            $queryParams = [':value' => $value];
+
+            if ($constraint->ignoreId !== null) {
+                $sql .= " AND `id` != :ignore_id";
+                $queryParams[':ignore_id'] = $constraint->ignoreId;
+            }
+
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute($queryParams);
+
+            if ($stmt->fetchColumn() > 0) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ field }}', $constraint->column)
+                    ->addViolation();
+            }
+        } catch (\PDOException $e) {
+            // In test environments or when database is not available,
+            // skip the unique validation rather than failing
+            if (getenv('APP_ENV') === 'testing' || str_contains($e->getMessage(), 'Access denied')) {
+                return;
+            }
+            throw $e;
+        }
+    }
+}

--- a/src/Core/Validation/Constraint/UniqueValidator.php
+++ b/src/Core/Validation/Constraint/UniqueValidator.php
@@ -47,9 +47,9 @@ class UniqueValidator extends ConstraintValidator
                     ->addViolation();
             }
         } catch (\PDOException $e) {
-            // In test environments or when database is not available,
-            // skip the unique validation rather than failing
-            if (getenv('APP_ENV') === 'testing' || str_contains($e->getMessage(), 'Access denied')) {
+            // In test environments, skip the unique validation rather than failing
+            // In production, rethrow the exception to surface database issues
+            if (getenv('APP_ENV') === 'testing') {
                 return;
             }
             throw $e;

--- a/src/Core/Validation/SymfonyValidator.php
+++ b/src/Core/Validation/SymfonyValidator.php
@@ -82,7 +82,7 @@ class SymfonyValidator
 
     private function validateUniqueRule(?string $value, string $rule, string $field): void
     {
-        if (empty($value)) {
+        if ($value === null || $value === '') {
             return;
         }
 

--- a/src/Core/Validation/SymfonyValidator.php
+++ b/src/Core/Validation/SymfonyValidator.php
@@ -10,10 +10,12 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class SymfonyValidator
 {
     private ValidatorInterface $validator;
+    private \PDO $pdo;
     private array $errors = [];
 
-    public function __construct()
+    public function __construct(\PDO $pdo)
     {
+        $this->pdo = $pdo;
         $this->validator = Validation::createValidator();
     }
 
@@ -90,7 +92,7 @@ class SymfonyValidator
         $ignoreId = $params[2] ?? null;
 
         try {
-            $pdo = Database::getInstance();
+            $pdo = $this->pdo;
             $sql = "SELECT COUNT(*) FROM `{$table}` WHERE `{$column}` = :value";
             $queryParams = [':value' => $value];
 
@@ -106,10 +108,7 @@ class SymfonyValidator
                 $this->errors[$field][] = "Значення поля '{$field}' вже існує.";
             }
         } catch (\PDOException $e) {
-            // In test environments, skip database validation
-            if (getenv('APP_ENV') === 'testing') {
-                return;
-            }
+            // In testing environment, re-throw the exception for proper testing
             throw $e;
         }
     }

--- a/src/Core/Validation/SymfonyValidator.php
+++ b/src/Core/Validation/SymfonyValidator.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Core\Validation;
+
+use App\Database\Database;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class SymfonyValidator
+{
+    private ValidatorInterface $validator;
+    private array $errors = [];
+
+    public function __construct()
+    {
+        $this->validator = Validation::createValidator();
+    }
+
+    /**
+     * Validate data against rules using Symfony Validator
+     *
+     * @param array $data Data to validate
+     * @param array $rules Validation rules in the format ['field' => ['rule1', 'rule2:param']]
+     * @return bool True if validation passes, false otherwise
+     */
+    public function validate(array $data, array $rules): bool
+    {
+        $this->errors = [];
+
+        $constraints = [];
+        $uniqueRules = [];
+
+        foreach ($rules as $field => $fieldRules) {
+            $fieldConstraints = [];
+            foreach ($fieldRules as $rule) {
+                if (str_starts_with($rule, 'unique:')) {
+                    $uniqueRules[$field] = $rule;
+                } else {
+                    $constraint = $this->parseRule($rule, $field);
+                    if ($constraint !== null) {
+                        $fieldConstraints[] = $constraint;
+                    }
+                }
+            }
+            if (!empty($fieldConstraints)) {
+                $constraints[$field] = $fieldConstraints;
+            }
+        }
+
+        // Create a simple data object for validation
+        $dataObject = new class($data) {
+            public function __construct(private array $data) {}
+
+            public function __get(string $name) {
+                return $this->data[$name] ?? null;
+            }
+        };
+
+        // Validate non-unique rules with Symfony Validator
+        foreach ($constraints as $field => $fieldConstraints) {
+            $value = $data[$field] ?? null;
+            $violations = $this->validator->validate($value, $fieldConstraints);
+
+            if (count($violations) > 0) {
+                $this->errors[$field] = [];
+                foreach ($violations as $violation) {
+                    $this->errors[$field][] = $violation->getMessage();
+                }
+            }
+        }
+
+        // Validate unique rules manually
+        foreach ($uniqueRules as $field => $rule) {
+            $this->validateUniqueRule($data[$field] ?? null, $rule, $field);
+        }
+
+        return empty($this->errors);
+    }
+
+    private function validateUniqueRule(?string $value, string $rule, string $field): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        $params = explode(',', substr($rule, 7));
+        $table = $params[0];
+        $column = $params[1] ?? $field;
+        $ignoreId = $params[2] ?? null;
+
+        try {
+            $pdo = Database::getInstance();
+            $sql = "SELECT COUNT(*) FROM `{$table}` WHERE `{$column}` = :value";
+            $queryParams = [':value' => $value];
+
+            if ($ignoreId !== null) {
+                $sql .= " AND `id` != :ignore_id";
+                $queryParams[':ignore_id'] = $ignoreId;
+            }
+
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute($queryParams);
+
+            if ($stmt->fetchColumn() > 0) {
+                $this->errors[$field][] = "Значення поля '{$field}' вже існує.";
+            }
+        } catch (\PDOException $e) {
+            // In test environments, skip database validation
+            if (getenv('APP_ENV') === 'testing') {
+                return;
+            }
+            throw $e;
+        }
+    }
+
+    private function parseRule(string $rule, string $field): ?object
+    {
+        if ($rule === 'required') {
+            return new Assert\NotBlank(['message' => "Поле '{$field}' обов'язкове для заповнення."]);
+        }
+
+        if ($rule === 'email') {
+            return new Assert\Email(['message' => "Поле '{$field}' повинно містити дійсну електронну адресу."]);
+        }
+
+        if (str_starts_with($rule, 'min:')) {
+            $minLength = (int)substr($rule, 4);
+            return new Assert\Length([
+                'min' => $minLength,
+                'minMessage' => "Поле '{$field}' повинно містити не менше {$minLength} символів."
+            ]);
+        }
+
+        if (str_starts_with($rule, 'max:')) {
+            $maxLength = (int)substr($rule, 4);
+            return new Assert\Length([
+                'max' => $maxLength,
+                'maxMessage' => "Поле '{$field}' повинно містити не більше {$maxLength} символів."
+            ]);
+        }
+
+        if ($rule === 'date') {
+            return new Assert\Date(['message' => "Поле '{$field}' повинно містити дійсну дату."]);
+        }
+
+        if ($rule === 'datetime') {
+            return new Assert\Callback(function($value, $context) use ($field) {
+                if (empty($value)) {
+                    return;
+                }
+                $dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                $dateTimeShort = \DateTime::createFromFormat('Y-m-d H:i', $value);
+                if (!$dateTime && !$dateTimeShort) {
+                    $context->buildViolation("Поле '{$field}' повинно містити дійсні дату та час.")
+                        ->addViolation();
+                }
+            });
+        }
+
+        if (str_starts_with($rule, 'in:')) {
+            $options = explode(',', substr($rule, 3));
+            return new Assert\Choice([
+                'choices' => $options,
+                'message' => "Поле '{$field}' повинно мати одне зі значень: " . implode(', ', $options) . "."
+            ]);
+        }
+
+        if ($rule === 'numeric') {
+            return new Assert\Regex([
+                'pattern' => '/^[0-9]+(\.[0-9]+)?$/',
+                'message' => "Поле '{$field}' повинно бути числом."
+            ]);
+        }
+
+        if (str_starts_with($rule, 'min_value:')) {
+            $minValue = (float)explode(':', $rule)[1];
+            return new Assert\GreaterThanOrEqual([
+                'value' => $minValue,
+                'message' => "Поле '{$field}' повинно бути не менше {$minValue}."
+            ]);
+        }
+
+        if (str_starts_with($rule, 'max_value:')) {
+            $maxValue = (float)explode(':', $rule)[1];
+            return new Assert\LessThanOrEqual([
+                'value' => $maxValue,
+                'message' => "Поле '{$field}' повинно бути не більше {$maxValue}."
+            ]);
+        }
+
+        if ($rule === 'array') {
+            return new Assert\Type([
+                'type' => 'array',
+                'message' => "Поле '{$field}' повинно бути масивом."
+            ]);
+        }
+
+        if (str_starts_with($rule, 'unique:')) {
+            // Unique validation is handled separately
+            return null;
+        }
+
+        return null;
+    }
+
+    public function addError(string $field, string $message): void
+    {
+        $this->errors[$field][] = $message;
+    }
+
+    public function hasErrors(): bool
+    {
+        return !empty($this->errors);
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Core/Validation/Validator.php
+++ b/src/Core/Validation/Validator.php
@@ -4,126 +4,37 @@ namespace App\Core\Validation;
 
 use PDO;
 
+/**
+ * Legacy Validator class - now uses SymfonyValidator internally for backward compatibility
+ * @deprecated Use SymfonyValidator directly for new code
+ */
 class Validator
 {
-    private array $errors = [];
-    private PDO $pdo;
+    private SymfonyValidator $symfonyValidator;
 
     public function __construct(PDO $pdo)
     {
-        $this->pdo = $pdo;
+        // PDO is no longer needed as SymfonyValidator handles database validation internally
+        $this->symfonyValidator = new SymfonyValidator($pdo);
     }
 
     public function validate(array $data, array $rules): bool
     {
-        foreach ($rules as $field => $ruleSet) {
-            foreach ($ruleSet as $rule) {
-                $value = $data[$field] ?? null;
-
-                if (is_string($rule) && str_starts_with($rule, 'required')) {
-                    if (empty($value)) {
-                        $this->errors[$field][] = "Поле '{$field}' є обов'язковим.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'email')) {
-                    if (!empty($value) && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути дійсною електронною адресою.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'min:')) {
-                    $min = (int)explode(':', $rule)[1];
-                    if (!empty($value) && strlen($value) < $min) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно містити щонайменше {$min} символів.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'datetime')) {
-                    if (!empty($value) && !\DateTime::createFromFormat('Y-m-d H:i:s', $value) && !\DateTime::createFromFormat('Y-m-d H:i', $value)) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути у форматі YYYY-MM-DD HH:MM:SS або YYYY-MM-DD HH:MM.";
-                    }
-                } elseif (is_string($rule) && $rule === 'date') {
-                    if (!empty($value) && !\DateTime::createFromFormat('Y-m-d', $value)) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути у форматі YYYY-MM-DD.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'in:')) {
-                    $options = explode(',', substr($rule, 3));
-                    if (!empty($value) && !in_array($value, $options)) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно мати одне зі значень: " . implode(', ', $options) . ".";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'numeric')) {
-                    if (!empty($value) && !is_numeric($value)) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути числом.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'min_value:')) {
-                    $minValue = (float)explode(':', $rule)[1];
-                    if (!empty($value) && is_numeric($value) && (float)$value < $minValue) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути не менше {$minValue}.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'max_value:')) {
-                    $maxValue = (float)explode(':', $rule)[1];
-                    if (!empty($value) && is_numeric($value) && (float)$value > $maxValue) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути не більше {$maxValue}.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'array')) {
-                    if (!empty($value) && !is_array($value)) {
-                        $this->errors[$field][] = "Поле '{$field}' повинно бути масивом.";
-                    }
-                }
-
-                if (is_string($rule) && str_starts_with($rule, 'unique:')) {
-                    $paramsStr = substr($rule, 7);
-                    $params = explode(',', $paramsStr);
-
-                    $table = $params[0];
-                    $column = $params[1] ?? $field;
-                    $ignoreId = $params[2] ?? null;
-
-                    if ($table && $column && !empty($value)) {
-                        $sql = "SELECT COUNT(*) FROM `{$table}` WHERE `{$column}` = :value";
-                        $queryParams = [':value' => $value];
-
-                        if ($ignoreId !== null) {
-                            $sql .= " AND `id` != :ignore_id";
-                            $queryParams[':ignore_id'] = $ignoreId;
-                        }
-
-                        $stmt = $this->pdo->prepare($sql);
-                        $stmt->execute($queryParams);
-                        if ($stmt->fetchColumn() > 0) {
-                            $this->errors[$field][] = "Значення поля '{$field}' вже існує.";
-                        }
-                    }
-                }
-            }
-        }
-
-        return empty($this->errors);
+        return $this->symfonyValidator->validate($data, $rules);
     }
 
     public function addError(string $field, string $message): void
     {
-        $this->errors[$field][] = $message;
+        $this->symfonyValidator->addError($field, $message);
     }
 
     public function hasErrors(): bool
     {
-        return !empty($this->errors);
+        return $this->symfonyValidator->hasErrors();
     }
 
     public function getErrors(): array
     {
-        return $this->errors;
+        return $this->symfonyValidator->getErrors();
     }
 }

--- a/src/Core/Validation/Validator.php
+++ b/src/Core/Validation/Validator.php
@@ -14,7 +14,7 @@ class Validator
 
     public function __construct(PDO $pdo)
     {
-        // PDO is no longer needed as SymfonyValidator handles database validation internally
+        // Pass PDO to SymfonyValidator for database-dependent validation (e.g., unique rule)
         $this->symfonyValidator = new SymfonyValidator($pdo);
     }
 

--- a/tests/Core/Validation/Constraint/UniqueTest.php
+++ b/tests/Core/Validation/Constraint/UniqueTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Core\Validation\Constraint;
+
+use PHPUnit\Framework\TestCase;
+
+class UniqueTest extends TestCase
+{
+    public function testConstructorSetsProperties(): void
+    {
+        $constraint = new Unique('users', 'email', 1, 'Custom message');
+
+        $this->assertEquals('users', $constraint->table);
+        $this->assertEquals('email', $constraint->column);
+        $this->assertEquals(1, $constraint->ignoreId);
+        $this->assertEquals('Custom message', $constraint->message);
+    }
+
+    public function testConstructorUsesDefaultMessage(): void
+    {
+        $constraint = new Unique('users', 'email');
+
+        $this->assertEquals('users', $constraint->table);
+        $this->assertEquals('email', $constraint->column);
+        $this->assertNull($constraint->ignoreId);
+        $this->assertEquals('Значення поля "{{ field }}" вже існує.', $constraint->message);
+    }
+
+    public function testGetTargetsReturnsPropertyConstraint(): void
+    {
+        $constraint = new Unique('users', 'email');
+        $this->assertEquals('property', $constraint->getTargets());
+    }
+}

--- a/tests/Core/Validation/Constraint/UniqueValidatorTest.php
+++ b/tests/Core/Validation/Constraint/UniqueValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Core\Validation\Constraint;
+
+use PHPUnit\Framework\TestCase;
+use PDO;
+use PDOStatement;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class UniqueValidatorTest extends TestCase
+{
+    private UniqueValidator $validator;
+    private PDO $mockPdo;
+    private PDOStatement $mockStmt;
+
+    protected function setUp(): void
+    {
+        $this->mockPdo = $this->createMock(PDO::class);
+        $this->mockStmt = $this->createMock(PDOStatement::class);
+        $this->mockPdo->expects($this->any())
+            ->method('prepare')
+            ->willReturn($this->mockStmt);
+        $this->validator = new UniqueValidator($this->mockPdo);
+    }
+
+    public function testValidatePassesWhenValueIsEmpty(): void
+    {
+        $constraint = new Unique('users', 'email');
+        $this->validator->validate('', $constraint);
+        $this->validator->validate(null, $constraint);
+
+        // No violations should be added for empty values
+        $this->assertTrue(true); // If we get here, no exception was thrown
+    }
+
+    public function testValidatePassesWhenNoDuplicateFound(): void
+    {
+        $this->mockStmt->expects($this->once())
+            ->method('execute')
+            ->with([':value' => 'test@example.com']);
+        $this->mockStmt->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn(0);
+
+        $constraint = new Unique('users', 'email');
+        $this->validator->validate('test@example.com', $constraint);
+
+        // No violations should be added
+        $this->assertTrue(true);
+    }
+
+    public function testValidateFailsWhenDuplicateFound(): void
+    {
+        $this->mockStmt->expects($this->once())
+            ->method('execute')
+            ->with([':value' => 'test@example.com']);
+        $this->mockStmt->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn(1);
+
+        $constraint = new Unique('users', 'email');
+
+        // Mock the context
+        $context = $this->createMock(ExecutionContextInterface::class);
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        
+        $context->expects($this->once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        
+        $violationBuilder->expects($this->once())
+            ->method('setParameter')
+            ->with('{{ field }}', 'email')
+            ->willReturn($violationBuilder);
+        
+        $violationBuilder->expects($this->once())
+            ->method('addViolation');
+
+        $this->validator->initialize($context);
+        $this->validator->validate('test@example.com', $constraint);
+
+        // Ensure the test performs assertions
+        $this->assertTrue(true);
+    }
+
+    public function testValidatePassesWhenDuplicateIsIgnored(): void
+    {
+        $this->mockStmt->expects($this->once())
+            ->method('execute')
+            ->with([':value' => 'test@example.com', ':ignore_id' => 1]);
+        $this->mockStmt->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn(0);
+
+        $constraint = new Unique('users', 'email', 1);
+        $this->validator->validate('test@example.com', $constraint);
+
+        // No violations should be added
+        $this->assertTrue(true);
+    }
+
+    public function testValidateThrowsExceptionForInvalidConstraint(): void
+    {
+        $constraint = $this->createMock(\Symfony\Component\Validator\Constraint::class);
+
+        $this->expectException(\Symfony\Component\Validator\Exception\UnexpectedTypeException::class);
+        $this->validator->validate('test@example.com', $constraint);
+    }
+
+    public function testConstructorAcceptsNullPdo(): void
+    {
+        $validator = new UniqueValidator(null);
+        $this->assertInstanceOf(UniqueValidator::class, $validator);
+    }
+}

--- a/tests/Core/Validation/ValidatorTest.php
+++ b/tests/Core/Validation/ValidatorTest.php
@@ -197,6 +197,15 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($this->validator->getErrors()['email']);
     }
 
+    public function testUniqueRulePassesWhenDuplicateIsIgnoredId(): void
+    {
+        $this->mockStmt->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn(0); // No duplicates found (current record ignored)
+        $result = $this->validator->validate(['email' => 'existing@example.com'], ['email' => ['unique:users,email,1']]);
+        $this->assertTrue($result);
+    }
+
     public function testHasErrorsReturnsTrueWhenErrorsExist(): void
     {
         $this->validator->validate(['name' => ''], ['name' => ['required']]);

--- a/tests/Core/Validation/ValidatorTest.php
+++ b/tests/Core/Validation/ValidatorTest.php
@@ -206,6 +206,18 @@ class ValidatorTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testUniqueRuleValidatesZeroValue(): void
+    {
+        $this->mockStmt->expects($this->once())
+            ->method('execute')
+            ->with([':value' => '0']);
+        $this->mockStmt->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn(0); // No duplicates found
+        $result = $this->validator->validate(['status' => '0'], ['status' => ['unique:users,status']]);
+        $this->assertTrue($result);
+    }
+
     public function testHasErrorsReturnsTrueWhenErrorsExist(): void
     {
         $this->validator->validate(['name' => ''], ['name' => ['required']]);


### PR DESCRIPTION
This PR transitions the project from a custom validation mechanism to the industry-standard **Symfony Validator** component. This shift allows for standardized constraints and improved extensibility while maintaining backward compatibility through the updated `Validator.php`.

### Key Changes

- **Symfony Validator Integration**: Introduced `SymfonyValidator` as the primary service for handling validation rules.
- **Custom Constraints**: Implemented `Unique` and `UniqueValidator` to handle database uniqueness checks, including support for `ignoreId`.
- **Backward Compatibility**: The legacy `Validator` class is now marked as `@deprecated` and internally delegates all validation tasks to the `SymfonyValidator`.
- **Bug Fixes**: 
  - Resolved a property duplication issue for `errors`.
  - Updated the dependency chain to ensure `PDO` is correctly passed to the validator for database-dependent rules.
- **Testing**: Added test cases for the unique rule to verify it correctly handles existing records when an ID is ignored.

### Technical Notes

- The `unique` rule is currently handled via a manual bridge within `SymfonyValidator` to ensure compatibility with the existing `unique:table,column,id` string format.
- ⚠️ **Note**: A PHPStan failure on line 192 regarding the `Type` constraint parameter is acknowledged and will be addressed in a follow-up commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch core validation to Symfony Validator for standard rules and easier extension. Adds a database Unique rule with ignoreId support, and keeps the old Validator working by delegating to the new service.

- **New Features**
  - Integrated symfony/validator and mapped existing string rules (required, email, min/max, date/datetime, in, numeric, min_value, max_value, array).
  - Added database Unique constraint with ignoreId and support for legacy format unique:table,column,id.
  - Deprecated Validator; it now delegates to SymfonyValidator.

- **Bug Fixes**
  - Defined errors property on SymfonyValidator and ensured PDO is injected for DB-dependent rules.
  - Added tests for the unique rule, including ignoreId and '0' value cases; production DB errors are no longer suppressed during unique checks.

<sup>Written for commit 7d00573325a7815bc31bf14fe05942dd74e8889a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

